### PR TITLE
Customer, Manager 도메인 수정

### DIFF
--- a/src/main/java/com/honey/reservation/domain/Customer.java
+++ b/src/main/java/com/honey/reservation/domain/Customer.java
@@ -3,33 +3,38 @@ package com.honey.reservation.domain;
 import com.honey.reservation.domain.baseentity.BaseTimeEntity;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Getter
+@ToString(callSuper = true)
+@Table(indexes = {
+        @Index(columnList = "name"),
+        @Index(columnList = "phoneNumber")
+})
 @Entity
 public class Customer extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(length = 50)
+    private String loginId;
 
-    @Setter @Column(unique = true, length = 50) private String loginId;
-    @Setter @Column(length = 50) private String password;
-    @Setter @Column(length = 10) private String name;
-    @Setter @Column(length = 20) private String phoneNumber;
+    @Setter
+    @Column(length = 50)
+    private String password;
+    @Setter
+    @Column(length = 10)
+    private String name;
+    @Setter
+    @Column(length = 20)
+    private String phoneNumber;
 
-    protected Customer() {}
-
-    private Customer(String loginId, String password, String name, String phoneNumber) {
-        this.loginId = loginId;
-        this.password = password;
-        this.name = name;
-        this.phoneNumber = phoneNumber;
+    protected Customer() {
     }
 
-    private Customer(Long id, String loginId, String password, String name, String phoneNumber) {
-        this.id = id;
+    private Customer(String loginId, String password, String name, String phoneNumber) {
         this.loginId = loginId;
         this.password = password;
         this.name = name;
@@ -40,8 +45,15 @@ public class Customer extends BaseTimeEntity {
         return new Customer(loginId, password, name, phoneNumber);
     }
 
-    public static Customer of(Long id, String loginId, String password, String name, String phoneNumber) {
-        return new Customer(id, loginId, password, name, phoneNumber);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Customer customer)) return false;
+        return getLoginId() != null && getLoginId().equals(customer.getLoginId());
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLoginId());
+    }
 }

--- a/src/main/java/com/honey/reservation/domain/Manager.java
+++ b/src/main/java/com/honey/reservation/domain/Manager.java
@@ -2,18 +2,19 @@ package com.honey.reservation.domain;
 
 import com.honey.reservation.domain.baseentity.BaseTimeEntity;
 import lombok.Getter;
+import lombok.ToString;
 
 import javax.persistence.*;
 
 @Getter
+@ToString(callSuper = true)
 @Entity
 public class Manager extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(length = 50)
+    private String loginId;
 
-    @Column(unique = true, length = 50) private String loginId;
     @Column(length = 50) private String password;
     @Column(length = 10) private String name;
 
@@ -25,18 +26,8 @@ public class Manager extends BaseTimeEntity {
         this.name = name;
     }
 
-    private Manager(Long id, String loginId, String password, String name) {
-        this.id = id;
-        this.loginId = loginId;
-        this.password = password;
-        this.name = name;
-    }
-
     public static Manager of(String loginId, String password, String name) {
         return new Manager(loginId, password, name);
     }
 
-    public static Manager of(Long id, String loginId, String password, String name) {
-        return new Manager(id, loginId, password, name);
-    }
 }

--- a/src/main/java/com/honey/reservation/domain/reservation/Reservation.java
+++ b/src/main/java/com/honey/reservation/domain/reservation/Reservation.java
@@ -5,13 +5,21 @@ import com.honey.reservation.domain.Manager;
 import com.honey.reservation.domain.baseentity.BaseTimeEntity;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import javax.persistence.*;
-import java.util.Objects;
 
 import static javax.persistence.FetchType.LAZY;
 
+@ToString(callSuper = true)
 @Getter
+@Table(indexes = {
+        @Index(columnList = "date"),
+        @Index(columnList = "time"),
+        @Index(columnList = "reservationStatus"),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "modifiedAt")
+})
 @Entity
 public class Reservation extends BaseTimeEntity {
 
@@ -19,9 +27,9 @@ public class Reservation extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(optional = false, fetch = LAZY) @JoinColumn(name = "customer_id")
+    @ManyToOne(optional = false, fetch = LAZY) @JoinColumn(name = "customer_login_id")
     private Customer customer;
-    @ManyToOne(optional = false, fetch = LAZY) @JoinColumn(name = "manager_id")
+    @ManyToOne(optional = false, fetch = LAZY) @JoinColumn(name = "manager_login_id")
     private Manager manager;
 
     @Setter @Embedded @Column(nullable = false) private ReservationDateTime reservationDateTime;
@@ -67,16 +75,5 @@ public class Reservation extends BaseTimeEntity {
         return new Reservation(id, customer, manager, reservationDateTime, description, reservationStatus);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Reservation that = (Reservation) o;
-        return getId() != null && getId().equals(that.getId());
-    }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(getId());
-    }
 }

--- a/src/main/java/com/honey/reservation/dto/CustomerDto.java
+++ b/src/main/java/com/honey/reservation/dto/CustomerDto.java
@@ -3,14 +3,14 @@ package com.honey.reservation.dto;
 import com.honey.reservation.domain.Customer;
 
 public record CustomerDto(
-        Long id, String loginId, String password, String name, String phoneNumber
+        String loginId, String password, String name, String phoneNumber
 ) {
-    public static CustomerDto of(Long id, String loginId, String password, String name, String phoneNumber) {
-        return new CustomerDto(id, loginId, password, name, phoneNumber);
+    public static CustomerDto of(String loginId, String password, String name, String phoneNumber) {
+        return new CustomerDto(loginId, password, name, phoneNumber);
     }
 
     public static CustomerDto from(Customer customer) {
-        return CustomerDto.of(customer.getId(), customer.getLoginId(), customer.getPassword(), customer.getName(), customer.getPhoneNumber());
+        return CustomerDto.of(customer.getLoginId(), customer.getPassword(), customer.getName(), customer.getPhoneNumber());
     }
 
     public Customer toEntity() {

--- a/src/main/java/com/honey/reservation/dto/ManagerDto.java
+++ b/src/main/java/com/honey/reservation/dto/ManagerDto.java
@@ -3,13 +3,13 @@ package com.honey.reservation.dto;
 import com.honey.reservation.domain.Manager;
 
 public record ManagerDto(
-        Long id, String name
+        String loginId, String name
 ) {
-    public static ManagerDto of(Long id, String name) {
-        return new ManagerDto(id, name);
+    public static ManagerDto of(String loginId, String name) {
+        return new ManagerDto(loginId, name);
     }
 
     public static ManagerDto from(Manager entity) {
-        return new ManagerDto(entity.getId(), entity.getName());
+        return new ManagerDto(entity.getLoginId(), entity.getName());
     }
 }

--- a/src/main/java/com/honey/reservation/dto/response/ReservationDetailResponse.java
+++ b/src/main/java/com/honey/reservation/dto/response/ReservationDetailResponse.java
@@ -7,23 +7,23 @@ import com.honey.reservation.dto.ReservationDto;
 
 public record ReservationDetailResponse(
         Long reservationId, ReservationDateTime reservationDateTime, String description, ReservationStatus reservationStatus,
-        Long customerId, String customerName, String phoneNumber, Long managerId, String managerName
+        String customerLoginId, String customerName, String phoneNumber, String managerLoginId, String managerName
 ) {
     public static ReservationDetailResponse of(
             Long reservationId, ReservationDateTime reservationDateTime, String description, ReservationStatus reservationStatus,
-            Long customerId, String customerName, String phoneNumber, Long managerId, String managerName
+            String customerLoginId, String customerName, String phoneNumber, String managerLoginId, String managerName
     ) {
         return new ReservationDetailResponse(
                 reservationId, reservationDateTime, description, reservationStatus,
-                customerId, customerName, phoneNumber, managerId, managerName
+                customerLoginId, customerName, phoneNumber, managerLoginId, managerName
         );
     }
 
     public static ReservationDetailResponse from(ReservationDto dto) {
         return ReservationDetailResponse.of(
                 dto.id(), dto.reservationDateTime(), dto.description(), dto.reservationStatus(),
-                dto.customerDto().id(), dto.customerDto().name(), dto.customerDto().phoneNumber(),
-                dto.managerDto().id(), dto.managerDto().name()
+                dto.customerDto().loginId(), dto.customerDto().name(), dto.customerDto().phoneNumber(),
+                dto.managerDto().loginId(), dto.managerDto().name()
         );
     }
 }

--- a/src/main/java/com/honey/reservation/repository/CustomerRepository.java
+++ b/src/main/java/com/honey/reservation/repository/CustomerRepository.java
@@ -7,9 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface CustomerRepository extends JpaRepository<Customer, Long> {
+public interface CustomerRepository extends JpaRepository<Customer, String> {
     @Query("select c.loginId from Customer c where c.loginId = :loginId")
     Optional<String> findLoginId(@Param("loginId") String loginId);
-
-    Optional<Customer> findByLoginId(String loginId);
 }

--- a/src/main/java/com/honey/reservation/repository/ManagerRepository.java
+++ b/src/main/java/com/honey/reservation/repository/ManagerRepository.java
@@ -3,5 +3,5 @@ package com.honey.reservation.repository;
 import com.honey.reservation.domain.Manager;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ManagerRepository extends JpaRepository<Manager, Long> {
+public interface ManagerRepository extends JpaRepository<Manager, String> {
 }

--- a/src/main/java/com/honey/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/honey/reservation/repository/ReservationRepository.java
@@ -4,5 +4,5 @@ import com.honey.reservation.domain.reservation.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-    void deleteByIdAndManager_id(Long reservationId, Long managerId);
+    void deleteByIdAndManager_loginId(Long reservationId, String managerLoginId);
 }

--- a/src/main/java/com/honey/reservation/service/LoginService.java
+++ b/src/main/java/com/honey/reservation/service/LoginService.java
@@ -22,7 +22,7 @@ public class LoginService {
 
     @Transactional(readOnly = true)
     public Optional<CustomerDto> loadUserByUsername(String username) {
-        return customerRepository.findByLoginId(username)
+        return customerRepository.findById(username)
                 .map(CustomerDto::from);
     }
 

--- a/src/main/java/com/honey/reservation/service/ReservationService.java
+++ b/src/main/java/com/honey/reservation/service/ReservationService.java
@@ -41,8 +41,8 @@ public class ReservationService {
     }
 
     public void saveReservation(ReservationDto dto) {
-        Customer customer = customerRepository.getReferenceById(dto.customerDto().id());
-        Manager manager = managerRepository.getReferenceById(dto.managerDto().id());
+        Customer customer = customerRepository.getReferenceById(dto.customerDto().loginId());
+        Manager manager = managerRepository.getReferenceById(dto.managerDto().loginId());
 
         Reservation reservation = dto.toEntity(customer, manager);
         reservationRepository.save(reservation);
@@ -52,7 +52,7 @@ public class ReservationService {
     public void updateReservation(Long reservationId, ReservationDto dto) {
         try {
             Reservation reservation = reservationRepository.getReferenceById(reservationId);
-            Customer customer = customerRepository.getReferenceById(dto.customerDto().id());
+            Customer customer = customerRepository.getReferenceById(dto.customerDto().loginId());
             updateReservationDateTime(dto, reservation, customer);
         } catch (EntityNotFoundException e) {
             log.warn("예약을 찾을 수 없습니다. {}", dto);
@@ -62,7 +62,7 @@ public class ReservationService {
     public void cancelReservation(Long reservationId, ReservationDto dto) {
         try {
             Reservation reservation = reservationRepository.getReferenceById(reservationId);
-            Customer customer = customerRepository.getReferenceById(dto.customerDto().id());
+            Customer customer = customerRepository.getReferenceById(dto.customerDto().loginId());
             if (reservation.getCustomer().equals(customer)) {
                 reservation.setReservationStatus(CANCEL);
             }
@@ -71,8 +71,8 @@ public class ReservationService {
         }
     }
 
-    public void deleteReservation(Long reservationId, Long managerId) {
-        reservationRepository.deleteByIdAndManager_id(reservationId, managerId);
+    public void deleteReservation(Long reservationId, String  managerLoginId) {
+        reservationRepository.deleteByIdAndManager_loginId(reservationId, managerLoginId);
     }
 
     private static void updateReservationDateTime(ReservationDto dto, Reservation reservation, Customer customer) {

--- a/src/test/java/com/honey/reservation/repository/CustomerRepositoryTest.java
+++ b/src/test/java/com/honey/reservation/repository/CustomerRepositoryTest.java
@@ -30,7 +30,7 @@ class CustomerRepositoryTest {
     void crud() {
         Customer customer = Customer.of("loginId", "pw", "honey", null);
         customerRepository.save(customer);
-        Customer findCustomer = customerRepository.findById(customer.getId()).get();
+        Customer findCustomer = customerRepository.findById(customer.getLoginId()).get();
 
         assertThat(customer).isEqualTo(findCustomer);
         findCustomer.setName("newName");
@@ -42,7 +42,7 @@ class CustomerRepositoryTest {
     @DisplayName("로그인 아이디 DB에 존재 O")
     @Test
     void givenExistingLoginId_whenSelectLoginId_thenResultIsNotEmpty() {
-        customerRepository.save(Customer.of(null, "loginId", "password", "name", "phoneNumber"));
+        customerRepository.save(Customer.of("loginId", "password", "name", "phoneNumber"));
         customerRepository.flush();
         Optional<String> findLoginId = customerRepository.findLoginId("loginId");
         assertThat(findLoginId).isNotEmpty();
@@ -51,7 +51,7 @@ class CustomerRepositoryTest {
     @DisplayName("로그인 아이디 DB에 존재 X")
     @Test
     void givenNotExistingLoginId_whenSelectLoginId_thenResultIsEmpty() {
-        customerRepository.save(Customer.of(null, "loginId", "password", "name", "phoneNumber"));
+        customerRepository.save(Customer.of("loginId", "password", "name", "phoneNumber"));
         customerRepository.flush();
         Optional<String> findLoginId = customerRepository.findLoginId("notExistLoginId");
         assertThat(findLoginId).isEmpty();
@@ -60,8 +60,8 @@ class CustomerRepositoryTest {
     @DisplayName("로그인 아이디로 Customer 찾기")
     @Test
     void givenLoginId_whenFindByLoginId_thenReturnOptionalCustomer() {
-        customerRepository.save(Customer.of(null, "loginId", "password", "name", "phoneNumber"));
-        Optional<Customer> findCustomer = customerRepository.findByLoginId("loginId");
+        customerRepository.save(Customer.of("loginId", "password", "name", "phoneNumber"));
+        Optional<Customer> findCustomer = customerRepository.findById("loginId");
         assertThat(findCustomer).isNotEmpty();
     }
 

--- a/src/test/java/com/honey/reservation/service/LoginServiceTest.java
+++ b/src/test/java/com/honey/reservation/service/LoginServiceTest.java
@@ -30,11 +30,11 @@ class LoginServiceTest {
     @DisplayName("회원가입 성공")
     @Test
     void givenCorrectCustomerDto_whenSignUp_thenSaveCustomer() {
-        CustomerDto dto = CustomerDto.of(null, "loginId", "password", "name", "01012345678");
+        CustomerDto dto = CustomerDto.of("loginId", "password", "name", "01012345678");
 
         loginService.signUpCustomer(dto);
 
-        Optional<Customer> findCustomer = customerRepository.findByLoginId("loginId");
+        Optional<Customer> findCustomer = customerRepository.findById("loginId");
 
         assertThat(findCustomer).isNotEmpty();
     }
@@ -42,8 +42,8 @@ class LoginServiceTest {
     @DisplayName("회원가입 실패")
     @Test
     void givenExistingCustomer_whenSignUp_thenFailedSave() {
-        customerRepository.save(Customer.of(1L, "existingLoginId", "password", "name", "01012345678"));
-        CustomerDto dto = CustomerDto.of(null, "existingLoginId", "password", "name", "01012345678");
+        customerRepository.save(Customer.of("existingLoginId", "password", "name", "01012345678"));
+        CustomerDto dto = CustomerDto.of("existingLoginId", "password", "name", "01012345678");
 
         assertThatThrownBy(() -> loginService.signUpCustomer(dto)).isInstanceOf(IllegalStateException.class);
     }

--- a/src/test/java/com/honey/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/honey/reservation/service/ReservationServiceTest.java
@@ -39,14 +39,14 @@ class ReservationServiceTest {
     void saveReservation() {
         ReservationDto reservationDto = createReservationDto();
 
-        given(customerRepository.getReferenceById(reservationDto.customerDto().id())).willReturn(createCustomer());
-        given(managerRepository.getReferenceById(reservationDto.managerDto().id())).willReturn(createManager());
+        given(customerRepository.getReferenceById(reservationDto.customerDto().loginId())).willReturn(createCustomer());
+        given(managerRepository.getReferenceById(reservationDto.managerDto().loginId())).willReturn(createManager());
         given(reservationRepository.save(any(Reservation.class))).willReturn(createReservation());
 
         sut.saveReservation(reservationDto);
 
-        then(customerRepository).should().getReferenceById(reservationDto.customerDto().id());
-        then(managerRepository).should().getReferenceById(reservationDto.managerDto().id());
+        then(customerRepository).should().getReferenceById(reservationDto.customerDto().loginId());
+        then(managerRepository).should().getReferenceById(reservationDto.managerDto().loginId());
         then(reservationRepository).should().save(any(Reservation.class));
     }
 
@@ -72,12 +72,12 @@ class ReservationServiceTest {
         ReservationDto reservationDto = createReservationDto();
 
         given(reservationRepository.getReferenceById(reservationDto.id())).willReturn(reservation);
-        given(customerRepository.getReferenceById(reservationDto.customerDto().id())).willReturn(customer);
+        given(customerRepository.getReferenceById(reservationDto.customerDto().loginId())).willReturn(customer);
 
         sut.updateReservation(reservation.getId(), reservationDto);
 
         then(reservationRepository).should().getReferenceById(reservationDto.id());
-        then(customerRepository).should().getReferenceById(reservationDto.customerDto().id());
+        then(customerRepository).should().getReferenceById(reservationDto.customerDto().loginId());
 
     }
 
@@ -88,29 +88,29 @@ class ReservationServiceTest {
         Customer customer = createCustomer();
         ReservationDto reservationDto = createReservationDto();
         given(reservationRepository.getReferenceById(reservationDto.id())).willReturn(reservation);
-        given(customerRepository.getReferenceById(reservationDto.customerDto().id())).willReturn(customer);
+        given(customerRepository.getReferenceById(reservationDto.customerDto().loginId())).willReturn(customer);
 
         sut.cancelReservation(reservation.getId(), reservationDto);
 
         then(reservationRepository).should().getReferenceById(reservationDto.id());
-        then(customerRepository).should().getReferenceById(reservationDto.customerDto().id());
+        then(customerRepository).should().getReferenceById(reservationDto.customerDto().loginId());
     }
 
 
     private Customer createCustomer() {
-        return Customer.of(1L, null, null, "customer", "phoneNumber");
+        return Customer.of("loginId", null, "customer", "phoneNumber");
     }
 
     private CustomerDto createCustomerDto() {
-        return CustomerDto.of(1L, "loginId", "password", "name", "phoneNumber");
+        return CustomerDto.of("loginId", "password", "name", "phoneNumber");
     }
 
     private Manager createManager() {
-        return Manager.of(1L, null, null, "manager");
+        return Manager.of("loginId", null, "manager");
     }
 
     private ManagerDto createManagerDto() {
-        return ManagerDto.of(1L, "manager");
+        return ManagerDto.of("loginId", "manager");
     }
 
     private Reservation createReservation() {


### PR DESCRIPTION
1. Customer와 Manager 도메인의 pk를 id -> loginId로 수정함. (기존의 id 필드는 삭제)
2. 테이블 인덱싱 추가

도메인이 바뀜에 따라 테스트, 메서드 코드 업데이트